### PR TITLE
Adjust square logo to avoid halo artifact if background is not white

### DIFF
--- a/pics/dandi-logo-square.svg
+++ b/pics/dandi-logo-square.svg
@@ -2,13 +2,6 @@
 <!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    id="Layer_1"
    x="0px"
@@ -18,10 +11,17 @@
    sodipodi:docname="dandi-logo-square.svg"
    width="1700"
    height="1700"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><metadata
    id="metadata22"><rdf:RDF><cc:Work
        rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
    id="defs20">
 		
 	
@@ -46,10 +46,13 @@
    fit-margin-left="0"
    fit-margin-right="0"
    fit-margin-bottom="0"
-   inkscape:zoom="0.27117629"
-   inkscape:cx="419.67499"
-   inkscape:cy="-409.28048"
-   inkscape:current-layer="Page-1" />
+   inkscape:zoom="0.87623793"
+   inkscape:cx="495.29926"
+   inkscape:cy="829.1127"
+   inkscape:current-layer="Group-5"
+   inkscape:showpageshadow="2"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1" />
 <style
    type="text/css"
    id="style2">
@@ -60,13 +63,26 @@
 	.st4{fill:#00436D;}
 </style>
 <g
+   inkscape:groupmode="layer"
+   id="layer1"
+   inkscape:label=" bg-blue"
+   style="display:none"
+   transform="matrix(0.98652905,0,0,0.97162176,11.13993,23.452856)"><rect
+     style="color:#000000;overflow:visible;fill:#0000ff;fill-rule:evenodd;stop-color:#000000"
+     id="rect299"
+     width="1722.511"
+     height="1749.339"
+     x="-10.618165"
+     y="-24.213179" /></g><g
    id="Page-1"
    transform="translate(-0.52260282,24.323855)">
 	<g
    id="g859"
-   transform="translate(149.34385)"><g
+   transform="translate(149.34385)"
+   inkscape:label="Logo"><g
      transform="translate(199.31946,246.52887)"
-     id="noun_Brain_38917">
+     id="noun_Brain_38917"
+     inkscape:label="Brain">
 				<polygon
    style="fill:#d3868d"
    points="1142.1,457.4 1119.8,596.9 951.7,664.8 844.1,536.5 647.5,235.3 641.1,162.5 774.5,40.4 922.4,162.5 1058.1,227.2 "
@@ -86,7 +102,8 @@
    id="Shape" />
 			</g><g
      transform="rotate(-40,464.2436,302.34202)"
-     id="Group-5">
+     id="Group-5"
+     inkscape:label="Hat">
 				
 					<ellipse
    ry="142"
@@ -94,20 +111,19 @@
    cy="451.60001"
    cx="368.39999"
    transform="rotate(179.99989,368.36285,451.61432)"
-   id="Oval-2" />
+   id="Oval-2"
+   inkscape:label="Base oval" />
 				<polygon
    points="656.5,83.1 628.7,433.2 127.9,433.2 100.1,83.1 "
-   id="Rectangle-5" />
+   id="polygon426"
+   style="display:inline;fill:#ffffff"
+   inkscape:label="white-cut-out" /><path
+   id="Rectangle-5"
+   d="M 656.50021 83.100182 L 618.32449 83.100423 A 92.5 287.89999 89.99989 0 1 620.40182 93.280211 A 92.5 287.89999 89.99989 0 1 332.50193 185.7807 A 92.5 287.89999 89.99989 0 1 105.42008 150.0776 L 127.90121 433.1998 L 628.69984 433.20098 L 656.50021 83.100182 z "
+   inkscape:label="Hat cylinder with cut out"
+   style="fill:#000000;stroke:#000000" />
 				
-					<ellipse
-   style="fill:#ffffff"
-   ry="92.5"
-   rx="287.89999"
-   cy="93.300003"
-   cx="332.5"
-   class="st3"
-   transform="rotate(179.99989,332.50041,93.290328)"
-   id="Oval-2-Copy-3" />
+					
 				
 					<ellipse
    ry="82.400002"
@@ -115,7 +131,8 @@
    cy="83.099998"
    cx="378.29999"
    transform="rotate(179.99989,378.29822,83.112072)"
-   id="Oval-2-Copy-2" />
+   id="Oval-2-Copy-2"
+   inkscape:label="Top oval" />
 			</g></g><path
    id="DANDI"
    class="st4"


### PR DESCRIPTION
- added meaningful names to the objects (Hat, Brain)
- intersected that "halo" reflection with cylinder to create "hat cylinder with cut out" object
- added copy of cylinder called "white-cut-out" so if we do not want white "reflection", just make it invisible
- there is `bg-blue` layer/object with blue rectangle to see how would look with non-white

here is preview how it would have looked on non-white background before:

![image](https://github.com/dandi/artwork/assets/39889/58253594-456f-4fed-813e-e78996b7a1be)

and now it would be 

![image](https://github.com/dandi/artwork/assets/39889/8e9bca53-e4ee-4974-a111-c93dcdb8bc16)

or if you disable "white-cut-out"

![image](https://github.com/dandi/artwork/assets/39889/926c58a3-9f52-4897-a5e6-ab3cc7ee5b79)

note: default -- no blue background, above just to visualize